### PR TITLE
Change HttpMethod log message parm to be a string rather than an object

### DIFF
--- a/package/Stackage.Aws.Lambda/LoggingHttpClientHandler.cs
+++ b/package/Stackage.Aws.Lambda/LoggingHttpClientHandler.cs
@@ -22,13 +22,13 @@ namespace Stackage.Aws.Lambda
 
       protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
       {
-         _logger.LogInformation("Sending HTTP request {HttpMethod} {Uri}", request.Method, request.RequestUri);
+         _logger.LogInformation("Sending HTTP request {HttpMethod} {Uri}", request.Method.Method, request.RequestUri);
 
          var stopwatch = Stopwatch.StartNew();
 
          HttpResponseMessage response;
 
-         using (_logger.BeginScope(new Dictionary<string, object?> {{"HttpMethod", request.Method}, {"Uri", request.RequestUri}}))
+         using (_logger.BeginScope(new Dictionary<string, object?> {{"HttpMethod", request.Method.Method}, {"Uri", request.RequestUri}}))
          {
             try
             {


### PR DESCRIPTION
At the moment this logs something like this:

```
    "HttpMethod": {
        "Method": "GET"
    }
```

Which causes problems as in other places in our codebase we log HttpMethod it as a string which seems to make more sense:

<img width="1381" alt="image" src="https://github.com/concilify/stackage-aws-lambda-nuget/assets/102154324/ceb455ed-7e43-404a-81f7-c3dd7eb51a7b">